### PR TITLE
Transcript translation, env samples

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,12 @@
+POSTGRES_NAME=postgres
+POSTGRES_USERNAME=postgres
+POSTGRES_PASSWORD=postgres # pragma: allowlist secret
+POSTGRES_HOST=db
+POSTGRES_PORT=5432
+ELEVENLABS_API_KEY=your_api_key_to_elevenlabs # pragma: allowlist secret
+AGENT_ID=polish_voice_agent_id
+AGENT_UA_ID=ukrainian_voice_agent_id
+AGENT_PHONE_NUMBER_ID=phone_number_id_from_elevenlabs
+TWILIO_SID=your_twilio_sid
+TWILIO_AUTH_TOKEN=your_twilio_auth_token
+OPENAI_API_KEY=your_openai_api_key # pragma: allowlist secret

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Once you have docker installed, follow these guidelines:
     AGENT_PHONE_NUMBER_ID=phone_number_id_from_elevenlabs
     TWILIO_SID=your_twilio_sid
     TWILIO_AUTH_TOKEN=your_twilio_auth_token
+    OPENAI_API_KEY=your_openai_api_key
     ```
 
 3. Make sure you are in the project's root folder and run the command:

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Once you have docker installed, follow these guidelines:
     There are two versions of this command: `docker-compose up` and `docker compose up`. The command `docker compose up` forces docker to use `docker_compose_v2` which is just better, more stable and more reliable.
    1. By running the above command, docker should:
      - launch faker, which will allow you to create a database and/or fill it with data
-     - will launch the backend and frontend of the application, allowing the browser to open the application, view data from the database and simulate the other day's hospital occupancy rates
+     - launch the backend and frontend of the application, allowing the browser to open the application, view data from the database and simulate the other day's hospital occupancy rates
    2. The whole process could take **even a few minutes**, especially when running for the first time
 4. If you see in docker logs that frontend container is starting to run, you can [visit the webapp in browser](http://localhost:8501)
 

--- a/backend/.env.sample
+++ b/backend/.env.sample
@@ -1,0 +1,5 @@
+POSTGRES_NAME=postgres
+POSTGRES_USERNAME=postgres
+POSTGRES_PASSWORD=postgres # pragma: allowlist secret
+POSTGRES_HOST=db
+POSTGRES_PORT=5432

--- a/faker/.env.sample
+++ b/faker/.env.sample
@@ -1,0 +1,5 @@
+POSTGRES_NAME=postgres
+POSTGRES_USERNAME=postgres
+POSTGRES_PASSWORD=postgres # pragma: allowlist secret
+POSTGRES_HOST=db
+POSTGRES_PORT=5432

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,2 @@
+pygettext.py
+.env.sample

--- a/frontend/.env.sample
+++ b/frontend/.env.sample
@@ -1,0 +1,7 @@
+ELEVENLABS_API_KEY=your_api_key_to_elevenlabs # pragma: allowlist secret
+AGENT_ID=polish_voice_agent_id
+AGENT_UA_ID=ukrainian_voice_agent_id
+AGENT_PHONE_NUMBER_ID=phone_number_id_from_elevenlabs
+TWILIO_SID=your_twilio_sid
+TWILIO_AUTH_TOKEN=your_twilio_auth_token
+OPENAI_API_KEY=your_openai_api_key # pragma: allowlist secret

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -19,7 +19,7 @@ RUN mkdir -p locales/en/LC_MESSAGES locales/pl/LC_MESSAGES
 RUN msgfmt -o locales/pl/LC_MESSAGES/base.mo locales/pl/LC_MESSAGES/base.po
 RUN msgfmt -o locales/en/LC_MESSAGES/base.mo locales/en/LC_MESSAGES/base.po
 
-COPY main.py agent.py *.json ./
+COPY main.py agent.py translate.py *.json ./
 
 EXPOSE 8501
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -19,7 +19,7 @@ RUN mkdir -p locales/en/LC_MESSAGES locales/pl/LC_MESSAGES
 RUN msgfmt -o locales/pl/LC_MESSAGES/base.mo locales/pl/LC_MESSAGES/base.po
 RUN msgfmt -o locales/en/LC_MESSAGES/base.mo locales/en/LC_MESSAGES/base.po
 
-COPY main.py agent.py translate.py *.json ./
+COPY *.py *.json ./
 
 EXPOSE 8501
 

--- a/frontend/agent.py
+++ b/frontend/agent.py
@@ -51,7 +51,7 @@ def call_patient(
     suggested_appointment_day: int,
     use_ua_agent: bool,
     phone_to_call: str,
-) -> str | None:
+) -> tuple[str, str] | None:
     """
     Calls a patient using the ElevenLabs API and initiates a conversation.
 
@@ -84,7 +84,8 @@ def call_patient(
             conversation_initiation_client_data=conversation_initiation_client_data,
         )
         logger.info(f"Conversation ID: {response.conversation_id}")
-        return response.conversation_id
+        lang = "pl" if not use_ua_agent else "ua"
+        return response.conversation_id, lang
     except Exception as e:
         logger.error(f"Error: {e}")
         return None

--- a/frontend/locales/en/LC_MESSAGES/base.po
+++ b/frontend/locales/en/LC_MESSAGES/base.po
@@ -86,9 +86,6 @@ msgstr "did not agree to reschedule"
 msgid "'s consent is unknown."
 msgstr "'s consent is unknown."
 
-msgid "Day"
-msgstr "Day"
-
 msgid "Call with"
 msgstr "Call with"
 

--- a/frontend/locales/en/LC_MESSAGES/base.po
+++ b/frontend/locales/en/LC_MESSAGES/base.po
@@ -97,6 +97,9 @@ msgstr "Failed to fetch data from the server."
 msgid "Failed to connect to the server"
 msgstr "Failed to connect to the server"
 
+msgid "Could not translate the transcript. Displaying in the original language"
+msgstr "Could not translate the transcript. Displaying in the original language"
+
 msgid "Failed to initiate the call. Please try again later."
 msgstr "Failed to initiate the call. Please try again later."
 

--- a/frontend/locales/en/LC_MESSAGES/base.po
+++ b/frontend/locales/en/LC_MESSAGES/base.po
@@ -97,6 +97,9 @@ msgstr "Failed to fetch data from the server."
 msgid "Failed to connect to the server"
 msgstr "Failed to connect to the server"
 
+msgid "Failed to initiate the call. Please try again later."
+msgstr "Failed to initiate the call. Please try again later."
+
 #: main.py:337
 msgid "Day"
 msgstr "Day"

--- a/frontend/locales/en/LC_MESSAGES/base.po
+++ b/frontend/locales/en/LC_MESSAGES/base.po
@@ -87,10 +87,10 @@ msgid "'s consent is unknown."
 msgstr "'s consent is unknown."
 
 msgid "Day"
-msgstr "Dzień"
+msgstr "Day"
 
 msgid "Call with"
-msgstr "Rozmowa z"
+msgstr "Call with"
 
 #: main.py:288
 msgid "Failed to fetch data from the server."

--- a/frontend/locales/pl/LC_MESSAGES/base.po
+++ b/frontend/locales/pl/LC_MESSAGES/base.po
@@ -98,6 +98,9 @@ msgstr "Nieudany odczyt danych z serwera"
 msgid "Failed to connect to the server"
 msgstr "Nieudane połączenie z serwerem"
 
+msgid "Failed to initiate the call. Please try again later."
+msgstr "Nie udało się wykonać połączenia. Spróbuj ponownie później."
+
 #: main.py:337
 msgid "Day"
 msgstr "Dzień"

--- a/frontend/locales/pl/LC_MESSAGES/base.po
+++ b/frontend/locales/pl/LC_MESSAGES/base.po
@@ -98,6 +98,9 @@ msgstr "Nieudany odczyt danych z serwera"
 msgid "Failed to connect to the server"
 msgstr "Nieudane połączenie z serwerem"
 
+msgid "Could not translate the transcript. Displaying in the original language"
+msgstr "Nie udało się przetłumaczyć transkryptu rozmowy. Wyświetlam transkrypt w oryginalnym języku"
+
 msgid "Failed to initiate the call. Please try again later."
 msgstr "Nie udało się wykonać połączenia. Spróbuj ponownie później."
 

--- a/frontend/locales/pl/LC_MESSAGES/base.po
+++ b/frontend/locales/pl/LC_MESSAGES/base.po
@@ -87,9 +87,6 @@ msgstr "nie wyraził/a zgody na zmianę terminu"
 msgid "'s consent is unknown."
 msgstr " nie odpowiedział/a na pytanie."
 
-msgid "Day"
-msgstr "Dzień"
-
 msgid "Call with"
 msgstr "Rozmowa z"
 

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -301,8 +301,8 @@ def handle_patient_rescheduling(
         )
         if conversation_id is None:
             raise Exception("Failed to obtain conversation id")
-        transcript = {**fetch_transcription(conversation_id), "language": lang}
-        return {**check_patient_consent_to_reschedule(conversation_id), "transcript": transcript}
+        transcript = fetch_transcription(conversation_id)
+        return {**check_patient_consent_to_reschedule(conversation_id), "transcript": transcript, "transcript_language": lang}
     else:
         return {"consent": None, "verified": None, "called": False}
 
@@ -336,7 +336,8 @@ def agent_call(
             new_day=calculate_simulation_date(st.session_state.day_for_simulation).strftime("%Y-%m-%d"),
             use_ua_agent=use_ua_agent,
         )
-    except Exception:
+    except Exception as e:
+        logger.info(str(e))
         main_tab.error(_("Failed to initiate the call. Please try again later."), icon="⚠️")
         return
 
@@ -376,6 +377,7 @@ def agent_call(
                 "day": st.session_state.day_for_simulation,
                 "patient": f"{name} {surname}",
                 "transcript": call_results["transcript"],
+                "language": call_results["transcript_language"],
             }
         )
 

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -385,7 +385,7 @@ def display_transcriptions():
             st.session_state.openai_client, transcript["transcript"], st.session_state.interface_language
         )
 
-        for message in translated_transcript:
+        for message in translated_transcript["transcript"]:
             msg = expander.chat_message(message["role"] if message["role"] == "user" else "ai")
             msg.write(message["message"])
 

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -58,7 +58,11 @@ if "transcriptions" not in st.session_state:
 if len(st.session_state.transcriptions) == 0:
     transcript_tab.info(_("No transcriptions avaiable, call patient in order to see transcriptions"))
 if "openai_client" not in st.session_state:
-    st.session_state.openai_client = get_openai_client()
+    try:
+        st.session_state.openai_client = get_openai_client()
+    except Exception as e:
+        st.error(_("Failed to initialize OpenAI client. Please check your API key and configuration."))
+        st.session_state.openai_client = None
 
 today = datetime.today().date()
 

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -393,9 +393,14 @@ def display_transcriptions():
         expander = transcript_tab.expander(f"{_('Day')} {transcript['day']}: {_('Call with')} {transcript['patient']}")
 
         if st.session_state.interface_language != transcript["language"]:
-            translated_transcript = translate(
-                st.session_state.openai_client, transcript["transcript"], st.session_state.interface_language
-            )
+            try:
+                translated_transcript = translate(
+                    st.session_state.openai_client, transcript["transcript"], st.session_state.interface_language
+                )
+            except Exception as e:
+                logger.info(e)
+                expander.info(_("Could not translate the transcript. Displaying in the original language"))
+                translated_transcript = transcript
         else:
             translated_transcript = transcript
 

--- a/frontend/main.py
+++ b/frontend/main.py
@@ -338,6 +338,7 @@ def agent_call(
         )
     except Exception:
         main_tab.error(_("Failed to initiate the call. Please try again later."), icon="⚠️")
+        return
 
     consent = call_results["consent"]
     st.session_state.consent = consent

--- a/frontend/models.py
+++ b/frontend/models.py
@@ -1,0 +1,22 @@
+from enum import Enum
+from typing import List
+
+from pydantic import BaseModel, ConfigDict
+
+
+class Role(Enum):
+    user = "user"
+    agent = "agent"
+
+
+class Message(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    role: Role
+    message: str
+
+
+class Transcript(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    transcript: List[Message]

--- a/frontend/requirements.txt
+++ b/frontend/requirements.txt
@@ -4,3 +4,4 @@ streamlit==1.41.1
 python-dotenv==1.0.1
 elevenlabs[pyaudio]==1.59
 streamlit-autorefresh==1.0.1
+openai

--- a/frontend/requirements.txt
+++ b/frontend/requirements.txt
@@ -4,4 +4,4 @@ streamlit==1.41.1
 python-dotenv==1.0.1
 elevenlabs[pyaudio]==1.59
 streamlit-autorefresh==1.0.1
-openai
+openai~=1.97.1

--- a/frontend/requirements.txt
+++ b/frontend/requirements.txt
@@ -1,7 +1,8 @@
 pandas==2.2.3
 requests==2.32.3
 streamlit==1.41.1
+openai~=1.97.1
+pydantic==2.11.4
 python-dotenv==1.0.1
 elevenlabs[pyaudio]==1.59
 streamlit-autorefresh==1.0.1
-openai~=1.97.1

--- a/frontend/translate.py
+++ b/frontend/translate.py
@@ -37,10 +37,9 @@ def translate(client: OpenAI, transcript: dict, lang: str) -> dict:
         EasyInputMessageParam(
             role="system",
             content=f"""You are a professional translator, your role is to translate a given transcript of a voice call between AI agent and human to the language: {lang}. \n
-                        Only return the translated transcript in the JSON format, nothing else. \n """
-            + 'The JSON format should look like this: {"transcript":[{"role":"<role>", "message":"<translated_message>"}, {...}]} \n'
-            + """Roles should not be translated! Just copy them from the source.
-                        Translate only the strings inside of the "message" attributes.
+                        Only return the translated transcript in the JSON format, nothing else. \n
+                        Roles should not be translated! Just copy them from the source. \n
+                        Translate only the strings inside of the "message" attributes. \n
                         Do not translate neither proper nouns nor proper names""",
         ),
         EasyInputMessageParam(role="user", content=json.dumps(transcript)),
@@ -52,9 +51,35 @@ def translate(client: OpenAI, transcript: dict, lang: str) -> dict:
         temperature=0.3,
         text=ResponseTextConfigParam(
             format=ResponseFormatTextJSONSchemaConfigParam(
-                name="translated messages", type="json_schema", schema=model_schema, strict=True
+                name="translated_messages", type="json_schema", schema=model_schema, strict=True
             )
         ),
     )
-    res = response.choices[0].message.content.strip()
+    res = response.output_text
     return json.loads(res)
+
+
+# client = get_openai_client()
+# mock_transcript = {
+#     "transcript": [
+#         {
+#             "role": "agent",
+#             "message": "Dzień dobry! Z tej strony asystent pacjenta ze Szpitala przy ulicy Szpitalnej w Poznaniu. Chciałbym zaproponować przełożenie wizyty na wcześniejszy termin. Czy mogę prosić o podanie imienia i nazwiska w celu weryfikacji?"
+#         },
+#         {
+#             "role": "user",
+#             "message": "Natan Dynia"
+#         },
+#         {
+#             "role": "agent",
+#             "message": "Dziękuję, panie Natanie. Aby potwierdzić tożsamość, proszę o podanie trzech ostatnich cyfr numeru PESEL."
+#         },
+#         {
+#             "role": "user",
+#             "message": "953" # jak tu będzie int, to nie przetłumaczy
+#         }
+#     ]
+# }
+# response = translate(client, mock_transcript, "en")
+# print(type(response))
+# print(response)

--- a/frontend/translate.py
+++ b/frontend/translate.py
@@ -16,7 +16,7 @@ def get_openai_client():
     """Initialize and return OpenAI client."""
     api_key = os.getenv("OPENAI_API_KEY")
     if not api_key:
-        raise Exception(
+        raise EnvironmentError(
             "OpenAI API key not found. Please set OPENAI_API_KEY environment variable "
             "or create a .env file with OPENAI_API_KEY=your_api_key"
         )
@@ -56,7 +56,10 @@ def translate(client: OpenAI, transcript: dict, lang: str) -> dict:
         ),
     )
     res = response.output_text
-    return json.loads(res)
+    try:
+        return json.loads(res)
+    except json.JSONDecodeError as e:
+        raise Exception(f"Failed to decode JSON from OpenAI response: {res}") from e
 
 
 # client = get_openai_client()

--- a/frontend/translate.py
+++ b/frontend/translate.py
@@ -62,27 +62,25 @@ def translate(client: OpenAI, transcript: dict, lang: str) -> dict:
         raise Exception(f"Failed to decode JSON from OpenAI response: {res}") from e
 
 
-# client = get_openai_client()
-# mock_transcript = {
-#     "transcript": [
-#         {
-#             "role": "agent",
-#             "message": "Dzień dobry! Z tej strony asystent pacjenta ze Szpitala przy ulicy Szpitalnej w Poznaniu. Chciałbym zaproponować przełożenie wizyty na wcześniejszy termin. Czy mogę prosić o podanie imienia i nazwiska w celu weryfikacji?"
-#         },
-#         {
-#             "role": "user",
-#             "message": "Natan Dynia"
-#         },
-#         {
-#             "role": "agent",
-#             "message": "Dziękuję, panie Natanie. Aby potwierdzić tożsamość, proszę o podanie trzech ostatnich cyfr numeru PESEL."
-#         },
-#         {
-#             "role": "user",
-#             "message": "953" # jak tu będzie int, to nie przetłumaczy
-#         }
-#     ]
-# }
-# response = translate(client, mock_transcript, "en")
-# print(type(response))
-# print(response)
+def test():
+    client = get_openai_client()
+    mock_transcript = {
+        "transcript": [
+            {
+                "role": "agent",
+                "message": "Dzień dobry! Z tej strony asystent pacjenta ze Szpitala przy ulicy Szpitalnej w Poznaniu. Chciałbym zaproponować przełożenie wizyty na wcześniejszy termin. Czy mogę prosić o podanie imienia i nazwiska w celu weryfikacji?",
+            },
+            {"role": "user", "message": "Natan Dynia"},
+            {
+                "role": "agent",
+                "message": "Dziękuję, panie Natanie. Aby potwierdzić tożsamość, proszę o podanie trzech ostatnich cyfr numeru PESEL.",
+            },
+            {
+                "role": "user",
+                "message": "953",  # jak tu będzie int, to nie przetłumaczy
+            },
+        ]
+    }
+    response = translate(client, mock_transcript, "en")
+    print(type(response))
+    print(response)

--- a/frontend/translate.py
+++ b/frontend/translate.py
@@ -1,8 +1,13 @@
 import json
 import os
+from typing import Any
 
 from dotenv import load_dotenv
+from models import Transcript
 from openai import OpenAI
+from openai.types.responses.easy_input_message_param import EasyInputMessageParam
+from openai.types.responses.response_format_text_json_schema_config_param import ResponseFormatTextJSONSchemaConfigParam
+from openai.types.responses.response_text_config_param import ResponseTextConfigParam
 
 load_dotenv()
 
@@ -27,21 +32,29 @@ def translate(client: OpenAI, transcript: dict, lang: str) -> dict:
     :param lang: language to translate to
     :return: translated messages
     """
-    response = client.chat.completions.create(
+    model_schema: dict[str, Any] = Transcript.model_json_schema()
+    input_messages = [
+        EasyInputMessageParam(
+            role="system",
+            content=f"""You are a professional translator, your role is to translate a given transcript of a voice call between AI agent and human to the language: {lang}. \n
+                        Only return the translated transcript in the JSON format, nothing else. \n """
+            + 'The JSON format should look like this: {"transcript":[{"role":"<role>", "message":"<translated_message>"}, {...}]} \n'
+            + """Roles should not be translated! Just copy them from the source.
+                        Translate only the strings inside of the "message" attributes.
+                        Do not translate neither proper nouns nor proper names""",
+        ),
+        EasyInputMessageParam(role="user", content=json.dumps(transcript)),
+    ]
+
+    response = client.responses.create(
         model="gpt-4o-mini",
-        messages=[
-            {
-                "role": "system",
-                "content": f"""You are a professional translator, your role is to translate a given transcript of a voice call between AI agent and human to the language: {lang}. \n
-                            Only return the translated transcript in the JSON format, nothing else. \n """
-                + 'The JSON format should look like this: {"transcript":[{"role":"<role>", "message":"<translated_message>"}, {...}]} \n'
-                + """Roles should not be translated! Just copy them from the source.
-                            Translate only the strings inside of the "message" attributes.
-                            Do not translate neither proper nouns nor proper names""",
-            },
-            {"role": "user", "content": json.dumps(transcript)},
-        ],
+        input=input_messages,
         temperature=0.3,
+        text=ResponseTextConfigParam(
+            format=ResponseFormatTextJSONSchemaConfigParam(
+                name="translated messages", type="json_schema", schema=model_schema, strict=True
+            )
+        ),
     )
     res = response.choices[0].message.content.strip()
     return json.loads(res)

--- a/frontend/translate.py
+++ b/frontend/translate.py
@@ -34,12 +34,12 @@ def translate(client: OpenAI, transcript: dict, lang: str) -> dict:
                 "role": "system",
                 "content": f"""You are a professional translator, your role is to translate a given transcript of a voice call between AI agent and human to the language: {lang}. \n
                             Only return the translated transcript in the JSON format, nothing else. \n """
-                + 'The JSON format should look like this: {"transcript":["role":"<role>", "message":"<translated_message>"]} \n'
+                + 'The JSON format should look like this: {"transcript":[{"role":"<role>", "message":"<translated_message>"}, {...}]} \n'
                 + """Roles should not be translated! Just copy them from the source.
                             Translate only the strings inside of the "message" attributes.
                             Do not translate neither proper nouns nor proper names""",
             },
-            {"role": "user", "content": transcript},
+            {"role": "user", "content": json.dumps(transcript)},
         ],
         temperature=0.3,
     )

--- a/frontend/translate.py
+++ b/frontend/translate.py
@@ -1,0 +1,47 @@
+import json
+import os
+
+from dotenv import load_dotenv
+from openai import OpenAI
+
+load_dotenv()
+
+
+def get_openai_client():
+    """Initialize and return OpenAI client."""
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise Exception(
+            "OpenAI API key not found. Please set OPENAI_API_KEY environment variable "
+            "or create a .env file with OPENAI_API_KEY=your_api_key"
+        )
+    return OpenAI(api_key=api_key)
+
+
+def translate(client: OpenAI, transcript: dict, lang: str) -> dict:
+    """
+    Translates the messages to a language passed as the lang parameter using provided openai client.
+
+    :param client: openai client to use
+    :param transcript: messages to translate
+    :param lang: language to translate to
+    :return: translated messages
+    """
+    response = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[
+            {
+                "role": "system",
+                "content": f"""You are a professional translator, your role is to translate a given transcript of a voice call between AI agent and human to the language: {lang}. \n
+                            Only return the translated transcript in the JSON format, nothing else. \n """
+                + 'The JSON format should look like this: {"transcript":["role":"<role>", "message":"<translated_message>"]} \n'
+                + """Roles should not be translated! Just copy them from the source.
+                            Translate only the strings inside of the "message" attributes.
+                            Do not translate neither proper nouns nor proper names""",
+            },
+            {"role": "user", "content": transcript},
+        ],
+        temperature=0.3,
+    )
+    res = response.choices[0].message.content.strip()
+    return json.loads(res)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ elevenlabs==1.59
 Faker==37.1.0
 fastapi==0.115.12
 fastapi[standard]
-openai
+openai~=1.97.1
 pandas==2.2.3
 psycopg2-binary==2.9.10
 pydantic==2.11.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ elevenlabs==1.59
 Faker==37.1.0
 fastapi==0.115.12
 fastapi[standard]
+openai
 pandas==2.2.3
 psycopg2-binary==2.9.10
 pydantic==2.11.4


### PR DESCRIPTION
### Key changes
- provided detailed list of env variables for each module, additionally in the project root folder, there is a `.env.sample` with all the variables 
- added the feature of translating transcripts to the interface language
  - the `translate()` function is tested and works as expected, however I was unable to test it in a whole running app due to lack of twilio
- added error handling in case of unauthenticated twilio
- removed duplicated translation in `base.po` files